### PR TITLE
Adding more descriptive logging

### DIFF
--- a/knex-store.js
+++ b/knex-store.js
@@ -27,7 +27,9 @@ module.exports = function CreateStore(entity, queries) {
 					query.then(function(res) {
 							cb(null, ent);
 						}, function(err) {
-							seneca.fail({ code: 'update', tag: args.tag$, store: entity,  error: err }, cb);
+							seneca.log.error(err['routine'])
+							seneca.log.error(err.detail ? err.detail : err.message);
+							seneca.fail({code: 'update', start: args.meta$.start, store: 'knex-store'}, cb);
 						});
 
 				} else {
@@ -40,7 +42,9 @@ module.exports = function CreateStore(entity, queries) {
 					query.then(function(res) {
 						cb(null, args.ent);
 					}, function(err) {
-						seneca.fail({code: 'save', tag: args.tag$, store: entity, error: err}, cb);
+						seneca.log.error(err['routine'])
+						seneca.log.error(err.detail ? err.detail : err.message);
+						seneca.fail({code: 'save', start: args.meta$.start, store: 'knex-store'}, cb);
 					});
 				}
 			},
@@ -62,8 +66,9 @@ module.exports = function CreateStore(entity, queries) {
 						cb(null, undefined);
 					}
 				}, function(err) {
-					seneca.log.error(query.toString(), query.values, trace.stack);
-					seneca.fail({code: 'load', tag: args.tag$, store: store.name, query: query, error: err}, cb);
+					seneca.log.error(err['routine'])
+					seneca.log.error(err.detail ? err.detail : err.message);
+					seneca.fail({code: 'load', start: args.meta$.start, store: 'knex-store'}, cb);
 				});
 			},
 
@@ -80,7 +85,9 @@ module.exports = function CreateStore(entity, queries) {
 						seneca.log(args.tag$, 'list', list.length, list[0]);
 						cb(null, list);
 					}, function(err) {
-						seneca.fail({code: 'list', tag: args.tag$, store: store.name, query: query, error: err}, cb);
+						seneca.log.error(err['routine'])
+						seneca.log.error(err.detail ? err.detail : err.message);
+						seneca.fail({code: 'list', start: args.meta$.start, store: 'knex-store'}, cb);
 					});
 
 			},

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "seneca": "^0.6.5"
   },
   "devDependencies": {
+    "pg": "^4.4.3",
     "sqlite3": "^3.1.0"
   }
 }

--- a/test/missing-column/connection.js
+++ b/test/missing-column/connection.js
@@ -1,0 +1,12 @@
+var knex = require('knex')({
+	client: 'pg',
+	connection: {
+		host     : '127.0.0.1',
+		user     : 'postgres',
+		database : 'postgres'
+	}
+});
+
+module.exports = function() {
+  return knex;
+}

--- a/test/missing-column/entity.test.js
+++ b/test/missing-column/entity.test.js
@@ -1,0 +1,68 @@
+var _ = require('lodash');
+var assert = require('assert');
+var queries = require('./queries');
+var seneca = require('seneca')();
+var uuid = require('node-uuid');
+
+var _entity = 'seneca_knex_test';
+var entityId = uuid.v4();
+var fixtureDate = new Date();
+
+fixtureDate = fixtureDate.toISOString();
+
+seneca.use(require('./'));
+
+var fixture = {
+	id: entityId,
+	title: 'entity.test.js',
+	content: 'this is a test',
+	created_by: 'entity.test.js',
+	created_date: fixtureDate
+};
+
+var knex = require('knex')({
+	client: 'pg',
+	connection: {
+		host     : '127.0.0.1',
+		user     : 'postgres',
+		database : 'postgres'
+	}
+});
+
+
+
+describe('seneca-knex-store entity test', function() {
+	before( function() {
+		knex.schema.hasTable('seneca_knex_test').then(function(exists) {
+			if (!exists) {
+				return knex.schema.createTable('seneca_knex_test', function(t) {
+					t.string('id');
+					t.string('title');
+					t.string('content');
+					t.date('created_by');
+					t.date('created_date');
+				});
+			}
+		});
+	})
+
+	after( function() {
+		knex.schema.dropTable('seneca_knex_test')
+	})
+
+	it('missing column', function(done) {
+
+		var ent = seneca.make$(_entity);
+
+		fixture['COLUMN_NOT_IN_TABLE'] = 'FAIL_ME'
+
+		ent = _.extend(ent, fixture);
+
+		ent.load$(function(err, res) {
+			assert.equal('seneca: load', err.message)
+			done();
+		});
+
+	});
+
+})

--- a/test/missing-column/index.js
+++ b/test/missing-column/index.js
@@ -1,0 +1,8 @@
+var queries = require('./queries');
+var store = require('../../knex-store.js');
+
+module.exports = function(opts) {
+	var seneca = this;
+
+	seneca.use(store('-/-/seneca_knex_test', queries));
+};

--- a/test/missing-column/queries.js
+++ b/test/missing-column/queries.js
@@ -1,0 +1,109 @@
+var _ = require('lodash');
+var assert = require('assert');
+var fs = require('fs');
+
+var query = require('./connection');
+var _entity = 'seneca_knex_test';
+
+var _columns = [
+	'id',
+	'title',
+	'content',
+	'created_by',
+	'created_date',
+	'COLUMN_NOT_IN_TABLE'
+];
+
+function _setColumns(opts) {
+	return {
+		id: opts.id,
+		content: opts.content,
+		title: opts.title,
+		created_by: opts.createdBy,
+		created_date: opts.createdDate
+	};
+}
+
+function _getColumns(opts) {
+	var result = [];
+
+	// this will fail when an unknown column comes through
+	_.each(_.keys(opts.ent), function (column) {
+		if (_columns.indexOf(column) >= 0) {
+			result.push(column);
+		}
+	});
+
+	return result;
+}
+
+function _setWhere(knex, opts) {
+
+	opts.id && knex.where('id', opts.id);
+
+	return knex;
+}
+
+function list(opts) {
+	var knex = query().table(_entity);
+	
+	knex.select(_getColumns(opts));
+
+	return knex;
+}
+
+function load(opts) {
+	assert(opts.q); // fail immediately if we're missing the q from seneca
+	var knex = query().table(_entity);
+
+	knex = _setWhere(knex, opts.q);
+	knex.select(_getColumns(opts));
+
+	return knex;
+}
+
+function insert(opts) {
+	var entity = opts.ent ? opts.ent : opts;
+	var knex = query().table(_entity);
+
+	knex.insert(_setColumns(entity));
+
+	return knex;
+}
+
+function update(opts) {
+	assert(opts.ent.id); // fail immediately if entity.id is missing or empty
+
+	var knex = query().table(_entity);
+	var columns = _.omit(_setColumns(opts.ent), 'id');
+
+	knex.where('id', opts.ent.id);
+	knex.update(columns);
+
+	return knex;
+}
+
+function remove(opts) {
+	assert(opts.q); // fail immediately if we're missing the q from seneca
+
+	var knex = query().table(_entity);
+
+	knex = _setWhere(knex, opts.q);
+	knex.del();
+
+	return knex;
+}
+
+
+function uninstall(opts) {
+
+	// return query().raw('drop table ' + _entity);
+};
+
+module.exports = {
+	insert: insert,
+	update: update,
+	load: load,
+	list: list,
+	remove: remove
+};


### PR DESCRIPTION
we ran into an issue with loading data using seneca-knex that was throwing:

```
Unhandled rejection ReferenceError: trace is not defined
    at /Users/robb/sites/nearForm/local_dev/.../node_modules/seneca-knex-store/knex-store.js:66:55
    at tryCatcher (/Users/robb/sites/nearForm/local_dev/.../node_modules/knex/node_modules/bluebird/js/main/util.js:26:23)
    at Promise._settlePromiseFromHandler (/Users/robb/sites/nearForm/local_dev/.../node_modules/knex/node_modules/bluebird/js/main/promise.js:507:31)
    at Promise._settlePromiseAt (/Users/robb/sites/nearForm/local_dev/.../node_modules/knex/node_modules/bluebird/js/main/promise.js:581:18)
    at Promise._settlePromises (/Users/robb/sites/nearForm/local_dev/.../node_modules/knex/node_modules/bluebird/js/main/promise.js:697:14)
    at Async._drainQueue (/Users/robb/sites/nearForm/local_dev/.../node_modules/knex/node_modules/bluebird/js/main/async.js:123:16)
    at Async._drainQueues (/Users/robb/sites/nearForm/local_dev/.../node_modules/knex/node_modules/bluebird/js/main/async.js:133:10)
    at Async.drainQueues (/Users/robb/sites/nearForm/local_dev/.../node_modules/knex/node_modules/bluebird/js/main/async.js:15:14)
    at process._tickDomainCallback (node.js:492:13) 
```

This PR fixes that issue and adds better logging around the actual problem.
